### PR TITLE
Returning proper worksheet names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ workBookReader.on('worksheet', function (workSheetReader) {
         workSheetReader.skip();
         return; 
     }
+    // print worksheet name
+    console.log(workSheetReader.name);
+
     // if we do not listen for rows we will only get end event
     // and have infor about the sheet like row count
     workSheetReader.on('row', function (row) {

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -41,6 +41,24 @@ function XlsxStreamReaderWorkBook(options){
 			writable: true,
 			enumerable: false
 		},
+		'workBookInfo': {
+			value: {
+				sheetRelationships: {},
+				sheetRelationshipsNames: {}
+			},
+			writable: true,
+			enumerable: false
+		},
+		'parsedWorkBookInfo': {
+			value: false,
+			writable: true,
+			enumerable: false
+		},
+		'parsedWorkBookRels': {
+			value: false,
+			writable: true,
+			enumerable: false
+		},
 		'parsedSharedStrings': {
 			value: false,
 			writable: true,
@@ -80,6 +98,7 @@ Util.inherits(XlsxStreamReaderWorkBook, Stream);
 
 XlsxStreamReaderWorkBook.prototype._handleWorkBookStream = function(){
 	var self = this;
+	var match;
 
 	self.on('pipe', function (srcPipe) {
 		srcPipe.pipe(Unzip2.Parse())
@@ -89,9 +108,19 @@ XlsxStreamReaderWorkBook.prototype._handleWorkBookStream = function(){
 				return;
 			}
 			switch (entry.path){
-				case "_rels/.rels":
 				case "xl/workbook.xml":
+					self._parseSax(entry, self._parseWorkBookInfo, function(){
+						self.parsedWorkBookInfo = true;
+						self.emit('workBookInfo');
+					});
+					break;
 				case "xl/_rels/workbook.xml.rels":
+					self._parseSax(entry, self._parseWorkBookRels, function(){
+						self.parsedWorkBookRels = true;
+						self.emit('workBookRels');
+					});
+					break;
+				case "_rels/.rels":
 					entry.autodrain();
 					break;
 				case "xl/sharedStrings.xml":
@@ -106,26 +135,29 @@ XlsxStreamReaderWorkBook.prototype._handleWorkBookStream = function(){
 					});
 					break;
 				default:
-					if (entry.path.match(/xl\/worksheets\/sheet\d+\.xml/)) {
-						var match = entry.path.match(/xl\/worksheets\/sheet(\d+)\.xml/)
-						var sheetNo = match[1];
+					if (match = entry.path.match(/xl\/(worksheets\/sheet(\d+)\.xml)/)) {
+						var sheetPath = match[1];
+						var sheetNo = match[2];
 
-						if (self.parsedSharedStrings == false || self.waitingWorkSheets.length > 0){
+						if (self.parsedWorkBookInfo == false
+							|| self.parsedWorkBookRels == false
+							|| self.parsedSharedStrings == false
+							|| self.waitingWorkSheets.length > 0){
+							
 							var stream = Temp.createWriteStream();
 
-							self.waitingWorkSheets.push({sheetNo: sheetNo, name: entry.path, path: stream.path})
+							self.waitingWorkSheets.push({sheetNo: sheetNo, name: entry.path, path: stream.path, sheetPath: sheetPath})
 
-							entry.pipe(stream)
+							entry.pipe(stream);
 
 						}else{
-							var workSheet = new XlsxStreamReaderWorkSheet(self, sheetNo, entry);
+							var name = self._getSheetName(sheetPath);
+							var workSheet = new XlsxStreamReaderWorkSheet(self, name, sheetNo, entry);
 
 							self.emit('worksheet',workSheet);
 						}
-					} else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+\.xml.rels/)) {
-						var match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)\.xml.rels/)
+					} else if (match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)\.xml.rels/)) {
 						var sheetNo = match[1];
-						console.log("_parseHyperlinks",sheetNo)
 					} else {
 						entry.autodrain();
 					}
@@ -136,11 +168,10 @@ XlsxStreamReaderWorkBook.prototype._handleWorkBookStream = function(){
 			if (self.waitingWorkSheets.length > 0){
 				var currentBook = 0;
 				var processBooks = function(){
-					var sheetInfo = self.waitingWorkSheets[currentBook]
-					
+					var sheetInfo = self.waitingWorkSheets[currentBook];
 					var entry = Fs.createReadStream(sheetInfo.path);
-					
-					var workSheet = new XlsxStreamReaderWorkSheet(self, sheetInfo.sheetNo, entry);
+					var name = self._getSheetName(sheetInfo.sheetPath);
+					var workSheet = new XlsxStreamReaderWorkSheet(self, name, sheetInfo.sheetNo, entry);
 
 					workSheet.on('end', function(node) {
 						++currentBook;
@@ -160,29 +191,29 @@ XlsxStreamReaderWorkBook.prototype._handleWorkBookStream = function(){
 			}
 		});
 	});
-}
+};
 
 XlsxStreamReaderWorkBook.prototype.abort = function(){
 	var self = this;
 
 	self.abortBook = true;
-}
+};
 
 XlsxStreamReaderWorkBook.prototype._parseSax = function(entryStream, entryHandler, endHandler){
 	var self = this;
 
 	var isErred = false;
 
-	var tmpNode = []
+	var tmpNode = [];
 	var tmpNodeEmit = false;
 
 	var saxOptions = {
 		trim: self.options.saxTrim,
 		position: self.options.saxPosition,
 		strictEntities: self.options.saxStrictEntities
-	}
+	};
 	
-	var saxStream = Sax.createStream(self.options.saxStrict, saxOptions)
+	var saxStream = Sax.createStream(self.options.saxStrict, saxOptions);
 	
 	entryStream.on('end', function(node) {
 		if (self.abortBook) return;
@@ -233,7 +264,7 @@ XlsxStreamReaderWorkBook.prototype._parseSax = function(entryStream, entryHandle
 	}catch(error){
 		self.emit('error',error);
 	}
-}
+};
 
 XlsxStreamReaderWorkBook.prototype._getSharedString = function(stringIndex){
 	var self = this;
@@ -243,7 +274,7 @@ XlsxStreamReaderWorkBook.prototype._getSharedString = function(stringIndex){
 		return;
 	}
 	return self.workBookSharedStrings[stringIndex];
-}
+};
 
 XlsxStreamReaderWorkBook.prototype._parseSharedStrings = function(nodeData){
 	var self = this;
@@ -258,7 +289,7 @@ XlsxStreamReaderWorkBook.prototype._parseSharedStrings = function(nodeData){
 			self.workBookSharedStrings.push("");
 		}
 	}
-}
+};
 
 XlsxStreamReaderWorkBook.prototype._parseStyles = function(nodeData){
 	var self = this;
@@ -266,4 +297,32 @@ XlsxStreamReaderWorkBook.prototype._parseStyles = function(nodeData){
 	nodeData.forEach(function(data){
 		self.workBookStyles.push(data);
 	});
-}
+};
+
+XlsxStreamReaderWorkBook.prototype._parseWorkBookInfo = function(nodeData){
+	var self = this;
+
+	nodeData.forEach(function(data){
+		if (data.name == 'sheet'){
+			self.workBookInfo.sheetRelationshipsNames[data.attributes['r:id']] = data.attributes.name;
+		}
+	});
+};
+
+XlsxStreamReaderWorkBook.prototype._parseWorkBookRels = function(nodeData){
+	var self = this;
+
+	nodeData.forEach(function(data){
+		if (data.name == 'Relationship'){
+			self.workBookInfo.sheetRelationships[data.attributes.Target] = data.attributes.Id;
+		}
+	});
+};
+
+XlsxStreamReaderWorkBook.prototype._getSheetName = function(sheetPath){
+	var self = this;
+
+	return self.workBookInfo.sheetRelationshipsNames[
+		self.workBookInfo.sheetRelationships[sheetPath]
+	];
+};

--- a/lib/worksheet.js
+++ b/lib/worksheet.js
@@ -11,10 +11,10 @@ const Stream = require('stream');
 
 module.exports = XlsxStreamReaderWorkSheet;
 
-function XlsxStreamReaderWorkSheet(workBook, workSheetId, workSheetStream){
+function XlsxStreamReaderWorkSheet(workBook, sheetName, workSheetId, workSheetStream){
 	var self = this;
 
-	if (!(this instanceof XlsxStreamReaderWorkSheet)) return new XlsxStreamReaderWorkSheet(workBook, workSheetId, workSheetStream);
+	if (!(this instanceof XlsxStreamReaderWorkSheet)) return new XlsxStreamReaderWorkSheet(workBook, sheetName, workSheetId, workSheetStream);
 
 	Object.defineProperties(this, { 
 		'id': {
@@ -25,7 +25,7 @@ function XlsxStreamReaderWorkSheet(workBook, workSheetId, workSheetStream){
 			value: workBook,
 		},
 		'name': {
-			value: 'sheet' + workSheetId,
+			value: sheetName,
 			enumerable: true,
 		},
 		'options': {


### PR DESCRIPTION
To return the actual worksheet names saved in the xlsx file, I've added the code that parses `xl/workbook.xml` and `xl/_rels/workbook.xml.rels`. In the result, two mappings are saved into new workbook variable `workBookInfo`: `sheetRelationships` and `sheetRelationshipsNames`. They are used together in the function `XlsxStreamReaderWorkBook.prototype._getSheetName` in order to retrieve the sheet name from its filename. The sheet name is passed to the `XlsxStreamReaderWorkSheet` constructor as the second argument and saved to its `name` field.