### PR TITLE
Do not emit error in _getSharedString function

### DIFF
--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -274,7 +274,6 @@ XlsxStreamReaderWorkBook.prototype._getSharedString = function(stringIndex){
 	var self = this;
 
 	if (stringIndex > self.workBookSharedStrings.length){
-		self.emit('error',"missing shared string: " + stringIndex);
 		return;
 	}
 	return self.workBookSharedStrings[stringIndex];


### PR DESCRIPTION
I am not sure why do we need this error emit

The reason why I've faced with this issue is that I tried to process several big xlsx (and xls) files. For my case big file was with 440k of rows.

When I'd removed this error emit files processed correctly

I am not sure is it a proper fix or maybe this is only a wrong workaround, maybe @DaSpawn you will say more about this