### PR TITLE
Fixes/formats

### DIFF
--- a/lib/worksheet.js
+++ b/lib/worksheet.js
@@ -242,7 +242,7 @@ XlsxStreamReaderWorkSheet.prototype._handleWorkSheetNode = function (nodeData) {
                   } catch (e) {
                     workingVal = ''
                   }
-                } else {
+                } else if (format !== 'General') {
                   try {
                     workingVal = ssf.format(format, Number(workingVal))
                   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xlsx-stream-reader",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Memory efficinet non-blocking/event based streaming XLSX reader",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixing situation, when when format is 'General' - in this case *ssf.format* won't work properly, because in docs https://www.npmjs.com/package/ssf#usage, ssf doesn't actually designed to work with 'General' - in this case we don't need to override `workingVal` variable